### PR TITLE
Update syntax for GHC 9

### DIFF
--- a/HUnit-Plus.cabal
+++ b/HUnit-Plus.cabal
@@ -1,6 +1,6 @@
 Name:                   HUnit-Plus
 Category:               Testing, Test
-Version:                2.0.0
+Version:                2.0.0.1
 License:                BSD3
 License-File:           LICENSE
 Author:                 Eric McCorkle

--- a/src/Test/HUnitPlus/Base.hs
+++ b/src/Test/HUnitPlus/Base.hs
@@ -151,7 +151,7 @@ executeTest :: Reporter us
             -> IO Progress
             -- ^ The test to run.
             -> IO (Double, State, us)
-executeTest rep @ Reporter { reporterCaseProgress = reportCaseProgress }
+executeTest rep@Reporter { reporterCaseProgress = reportCaseProgress }
             ss usInitial runTest =
   let
     -- Run the test until a finished result is produced
@@ -203,7 +203,7 @@ reportTestInfo result Reporter { reporterError = reportError,
                                  reporterFailure = reportFailure,
                                  reporterSystemOut = reportSystemOut,
                                  reporterSystemErr = reportSystemErr }
-               ss @ State { stCounts = c @ Counts { cAsserts = asserts,
+               ss@State { stCounts = c@Counts { cAsserts = asserts,
                                                     cFailures = failures,
                                                     cErrors = errors } }
                initialUs =
@@ -281,7 +281,7 @@ heartbeat = modifyIORef testinfo (\t -> t { tiHeartbeat = True })
 withPrefix :: Strict.Text -> IO () -> IO ()
 withPrefix prefix c =
   do
-    t @ TestInfo { tiPrefix = oldprefix } <- readIORef testinfo
+    t@TestInfo { tiPrefix = oldprefix } <- readIORef testinfo
     writeIORef testinfo t { tiPrefix = Strict.concat [prefix, oldprefix] }
     c
     modifyIORef testinfo (\t' -> t' { tiPrefix = oldprefix })
@@ -626,21 +626,21 @@ class Testable t where
   test = testNameTags syntheticName []
 
 instance Testable Test where
-  testNameTags newname newtags g @ Group { groupTests = testlist } =
+  testNameTags newname newtags g@Group { groupTests = testlist } =
     g { groupName = newname, groupTests = map (testTags newtags) testlist }
-  testNameTags newname newtags (Test t @ TestInstance { tags = oldtags }) =
+  testNameTags newname newtags (Test t@TestInstance { tags = oldtags }) =
     Test t { name = newname, tags = newtags ++ oldtags }
   testNameTags newname newtags (ExtraOptions opts t) =
     ExtraOptions opts (testNameTags newname newtags t)
 
-  testTags newtags g @ Group { groupTests = testlist } =
+  testTags newtags g@Group { groupTests = testlist } =
     g { groupTests = map (testTags newtags) testlist }
-  testTags newtags (Test t @ TestInstance { tags = oldtags }) =
+  testTags newtags (Test t@TestInstance { tags = oldtags }) =
     Test t { tags = newtags ++ oldtags }
   testTags newtags (ExtraOptions opts t) =
     ExtraOptions opts (testTags newtags t)
 
-  testName newname g @ Group {} = g { groupName = newname }
+  testName newname g@Group {} = g { groupName = newname }
   testName newname (Test t) = Test t { name = newname }
   testName newname (ExtraOptions opts t) =
     ExtraOptions opts (testName newname t)

--- a/src/Test/HUnitPlus/Execution.hs
+++ b/src/Test/HUnitPlus/Execution.hs
@@ -40,14 +40,14 @@ performTestCase :: Reporter us
                 -> TestInstance
                 -- ^ The test to be executed.
                 -> IO (State, us)
-performTestCase rep @ Reporter { reporterStartCase = reportStartCase,
+performTestCase rep@Reporter { reporterStartCase = reportStartCase,
                                   reporterError = reportError,
                                   reporterEndCase = reportEndCase }
-                ss @ State { stCounts = c @ Counts { cTried = tried,
+                ss@State { stCounts = c@Counts { cTried = tried,
                                                      cCases = cases },
                               stName = oldname, stOptions = optmap,
                               stOptionDescs = descs } initialUs
-                initTi @ TestInstance { name = testname,
+                initTi@TestInstance { name = testname,
                                         options = testdescs,
                                         setOption = setopt } =
   let
@@ -97,7 +97,7 @@ skipTestCase :: Reporter us
              -- ^ The test to be executed.
              -> IO (State, us)
 skipTestCase Reporter { reporterSkipCase = reportSkipCase }
-             ss @ State { stCounts = c @ Counts { cSkipped = skipped,
+             ss@State { stCounts = c@Counts { cSkipped = skipped,
                                                   cCases = cases },
                           stName = oldname } us
              TestInstance { name = testname } =
@@ -132,7 +132,7 @@ performTest rep initSelector initialState initialUs initialTest =
     --
     -- We also have to keep a set of tags by which we're filtering.
     -- The empty tag set means we don't actually filter at all.
-    performTest' s @ Selector { selectorInners = inners,
+    performTest' s@Selector { selectorInners = inners,
                                 selectorTags = currtags }
                  ss us Group { groupTests = testlist, groupName = gname } =
       let
@@ -146,7 +146,7 @@ performTest rep initSelector initialState initialUs initialTest =
                            selectorTags = currtags }
             -- Otherwise, combine the inner's tag state with ours and
             -- carry on.
-            Just inner @ Selector { selectorTags = innertags } ->
+            Just inner@Selector { selectorTags = innertags } ->
               inner { selectorTags = combineTags currtags innertags }
 
         -- Update the path for running the group's tests
@@ -160,7 +160,7 @@ performTest rep initSelector initialState initialUs initialTest =
         -- Return the state, reset to the old path
         return (ssAfter { stPath = oldpath }, usAfter)
     performTest' Selector { selectorInners = inners, selectorTags = currtags }
-                 ss us (Test t @ TestInstance { name = testname,
+                 ss us (Test t@TestInstance { name = testname,
                                                 tags = testtags }) =
       let
         -- Get the final tag state
@@ -186,7 +186,7 @@ performTest rep initSelector initialState initialUs initialTest =
         if canExecute
           then performTestCase rep ss us t
           else skipTestCase rep ss us t
-    performTest' selector ss @ State { stOptionDescs = descs }
+    performTest' selector ss@State { stOptionDescs = descs }
                  us (ExtraOptions newopts inner) =
       performTest' selector ss { stOptionDescs = descs ++ newopts } us inner
   in do
@@ -209,10 +209,10 @@ performTestSuiteInstance :: Reporter us
                          -> TestSuite
                          -- ^ Test suite to be run.
                          -> IO (State, us)
-performTestSuiteInstance rep @ Reporter { reporterStartSuite = reportStartSuite,
+performTestSuiteInstance rep@Reporter { reporterStartSuite = reportStartSuite,
                                           reporterEndSuite = reportEndSuite }
                          instopts selector
-                         st @ State { stOptions = stopts } initialUs
+                         st@State { stOptions = stopts } initialUs
                          TestSuite { suiteName = sname, suiteTests = testlist,
                                      suiteOptions = suiteOpts } =
   let
@@ -231,7 +231,7 @@ performTestSuiteInstance rep @ Reporter { reporterStartSuite = reportStartSuite,
     timestamp <- getCurrentTime
     state <- makestate timestamp
     startedUs <- reportStartSuite state initialUs
-    (time, (finishedState @ State { stCounts = counts }, finishedUs)) <-
+    (time, (finishedState@State { stCounts = counts }, finishedUs)) <-
       timeItT (foldM foldfun (state, startedUs) testlist)
     endedUs <- reportEndSuite time finishedState finishedUs
     return (finishedState { stCounts = counts { cCaseAsserts = 0 } },
@@ -255,7 +255,7 @@ performTestSuiteInternal :: Reporter us
                          -- ^ Test suite to be run.
                          -> IO (State, us)
 performTestSuiteInternal rep filters initialSs initialUs
-                         suite @ TestSuite { suiteName = sname } =
+                         suite@TestSuite { suiteName = sname } =
   case HashMap.lookup sname filters of
     Just optmap ->
       let
@@ -298,7 +298,7 @@ performTestSuites :: Reporter us
                   -> [TestSuite]
                   -- ^ Test suite to be run.
                   -> IO (Counts, us)
-performTestSuites rep @ Reporter { reporterStart = reportStart,
+performTestSuites rep@Reporter { reporterStart = reportStart,
                                    reporterEnd = reportEnd }
                   filters suites =
   let

--- a/src/Test/HUnitPlus/Filter.hs
+++ b/src/Test/HUnitPlus/Filter.hs
@@ -228,7 +228,7 @@ noOptionsAllSelector = HashMap.singleton HashMap.empty allSelector
 
 -- | Eliminate redundant nested tags from a Selector.
 reduceSelector :: Maybe (HashSet Strict.Text) -> Selector -> Maybe Selector
-reduceSelector parentTags s @ Selector { selectorInners = inners,
+reduceSelector parentTags s@Selector { selectorInners = inners,
                                          selectorTags = tags } =
   let
     newTags = diffTags tags parentTags
@@ -248,9 +248,9 @@ combineSelectors selector1 selector2 =
                            Selector -> Selector ->
                            Maybe Selector
     tryCombineSelectors parentTags
-                        s1 @ Selector { selectorInners = inners1,
+                        s1@Selector { selectorInners = inners1,
                                         selectorTags = tags1 }
-                        s2 @ Selector { selectorInners = inners2,
+                        s2@Selector { selectorInners = inners2,
                                         selectorTags = tags2 }
         -- Short-circuit case for allSelector.
       | s1 == allSelector || s2 == allSelector = Just allSelector

--- a/src/Test/HUnitPlus/Main.hs
+++ b/src/Test/HUnitPlus/Main.hs
@@ -284,7 +284,7 @@ createMain suites =
 -- to supply their own options, and to decide what to do with the
 -- result of test execution.
 topLevel :: [TestSuite] -> Opts -> IO (Either [Strict.Text] Bool)
-topLevel suites cmdopts @ Opts { consmode = cmodeopt } =
+topLevel suites cmdopts@Opts { consmode = cmodeopt } =
   let
     cmode = case cmodeopt of
       [] -> Right Text

--- a/src/Test/HUnitPlus/Terminal.hs
+++ b/src/Test/HUnitPlus/Terminal.hs
@@ -40,8 +40,8 @@ ta f bs as ('\n':cs) = ta (\t -> f (reverse bs ++ as ++ '\n' : t)) "" "" cs
 ta f bs as ('\r':cs) = ta f "" (reverse bs ++ as) cs
 ta f (b:bs) as ('\b':cs) = ta f bs (b:as) cs
 ta _ "" _ ('\b': _) = error "'\\b' at beginning of line"
-ta f bs as (c:cs) 
+ta f bs as (c:cs)
     | not (isPrint c) = error "invalid nonprinting character"
     | null as = ta f (c:bs) "" cs
-    | otherwise = ta f (c:bs) (tail as) cs
+    | otherwise = ta f (c:bs) (drop 1 as) cs
 ta f bs as "" = f (reverse bs ++ as)

--- a/src/Test/HUnitPlus/Text.hs
+++ b/src/Test/HUnitPlus/Text.hs
@@ -163,7 +163,7 @@ runTestText :: PutText us
             -> Test
             -- ^ The test to run
             -> IO (Counts, us)
-runTestText puttext @ (PutText put us0) verbose t =
+runTestText puttext@(PutText put us0) verbose t =
   let
     initState = State { stCounts = zeroCounts, stName = "",
                         stPath = [], stOptions = HashMap.empty,
@@ -190,8 +190,8 @@ runSuiteText :: PutText us
              -> TestSuite
              -- ^ The test suite to run.
              -> IO (Counts, us)
-runSuiteText puttext @ (PutText put us0) verbose
-             suite @ TestSuite { suiteName = sname } =
+runSuiteText puttext@(PutText put us0) verbose
+             suite@TestSuite { suiteName = sname } =
   let
     selectorMap = HashMap.singleton sname (HashMap.singleton HashMap.empty
                                                              allSelector)
@@ -216,7 +216,7 @@ runSuitesText :: PutText us
               -> [TestSuite]
               -- ^ The test to run
               -> IO (Counts, us)
-runSuitesText puttext @ (PutText put _) verbose suites =
+runSuitesText puttext@(PutText put _) verbose suites =
   let
     suiteNames = map suiteName suites
     selectorMap =
@@ -313,7 +313,7 @@ runTestTT t =
 -- This function is deprecated.  The preferred way to run tests is to
 -- use the functions in "Test.HUnitPlus.Main".
 runSuiteTT :: TestSuite -> IO Counts
-runSuiteTT suite @ TestSuite { suiteName = sname } =
+runSuiteTT suite@TestSuite { suiteName = sname } =
   let
     selectorMap = HashMap.singleton sname (HashMap.singleton HashMap.empty
                                                              allSelector)

--- a/test/Tests/Test/HUnitPlus/Execution.hs
+++ b/test/Tests/Test/HUnitPlus/Execution.hs
@@ -84,14 +84,14 @@ makeAssert (Normal (Fail msg)) = assertFailure (Strict.pack msg)
 makeAssert (Normal (Error msg)) = abortError (Strict.pack msg)
 makeAssert Exception = throwIO TestException
 
-updateCounts (Normal Pass) c @ Counts { cAsserts = asserts } =
+updateCounts (Normal Pass) c@Counts { cAsserts = asserts } =
   c { cAsserts = asserts + 1, cCaseAsserts = 1 }
-updateCounts (Normal (Fail _)) c @ Counts { cFailures = fails,
+updateCounts (Normal (Fail _)) c@Counts { cFailures = fails,
                                             cAsserts = asserts } =
   c { cFailures = fails + 1, cAsserts = asserts + 1, cCaseAsserts = 1 }
-updateCounts (Normal (Error _)) c @ Counts { cErrors = errors } =
+updateCounts (Normal (Error _)) c@Counts { cErrors = errors } =
   c { cErrors = errors + 1, cCaseAsserts = 0 }
-updateCounts Exception c @ Counts { cErrors = errors } =
+updateCounts Exception c@Counts { cErrors = errors } =
   c { cErrors = errors + 1, cCaseAsserts = 0 }
 
 makeName :: (Bool, Bool, Behavior) -> Strict.Text
@@ -99,7 +99,7 @@ makeName (tag1, tag2, res) =
   Strict.concat [makeTagName tag1 tag2, "_", makeResName res]
 
 makeTest :: String -> (Bool, Bool, Behavior) -> Test
-makeTest prefix tdata @ (tag1, tag2, res) =
+makeTest prefix tdata@(tag1, tag2, res) =
   let
     inittags = if tag1 then ["tag1"] else []
     tags = if tag2 then "tag2" : inittags else inittags
@@ -119,10 +119,10 @@ makeTestData :: String -> ([Test], [ReportEvent], State) ->
                 ([Test], [ReportEvent], State)
 makeTestData prefix
              (tests, events,
-              ss @ State { stName = oldname,
-                           stCounts = counts @ Counts { cCases = cases,
+              ss@State { stName = oldname,
+                           stCounts = counts@Counts { cCases = cases,
                                                         cTried = tried } })
-             (Right tdata @ (tag1, tag2, res)) =
+             (Right tdata@(tag1, tag2, res)) =
   let
     startedCounts = counts { cCases = cases + 1, cTried = tried + 1 }
     finishedCounts = updateCounts res startedCounts
@@ -149,8 +149,8 @@ makeTestData prefix
     (makeTest prefix tdata : tests, newevents,
      ssFinished { stName = oldname })
 makeTestData prefix
-             (tests, events, ss @ State { stCounts =
-                                             c @ Counts { cSkipped = skipped,
+             (tests, events, ss@State { stCounts =
+                                             c@Counts { cSkipped = skipped,
                                                           cCases = cases },
                                           stName = oldname })
              (Left tdata) =
@@ -178,14 +178,14 @@ testData = foldl (\accum tag1 ->
                          accum tagVals)
                  [] tagVals
 
-tag1Filter tdata @ (True, _, _) = Right tdata
+tag1Filter tdata@(True, _, _) = Right tdata
 tag1Filter tdata = Left tdata
 
-tag2Filter tdata @ (_, True, _) = Right tdata
+tag2Filter tdata@(_, True, _) = Right tdata
 tag2Filter tdata = Left tdata
 
-tag12Filter tdata @ (True, _, _) = Right tdata
-tag12Filter tdata @ (_, True, _) = Right tdata
+tag12Filter tdata@(True, _, _) = Right tdata
+tag12Filter tdata@(_, True, _) = Right tdata
 tag12Filter tdata = Left tdata
 
 data ModFilter = All | WithTags (Bool, Bool) | None deriving Show
@@ -252,7 +252,7 @@ makeLeafGroup gname wrapinner mfilter initialTests =
     mapfun :: ([Test], [ReportEvent], State, [Selector]) ->
               (ModFilter, Selector, Bool) ->
               ([Test], [ReportEvent], State, [Selector])
-    mapfun (tests, events, ss @ State { stPath = oldpath }, selectors)
+    mapfun (tests, events, ss@State { stPath = oldpath }, selectors)
            (mfilter, selector, valid) =
       let
         ssWithPath = ss { stPath = Label (Strict.pack gname) : oldpath }
@@ -280,7 +280,7 @@ makeOuterGroup mfilter initialTests =
     mapfun :: ([Test], [ReportEvent], State, [Selector]) ->
               (ModFilter, Selector, Bool) ->
               [([Test], [ReportEvent], State, [Selector])]
-    mapfun (tests, events, ss @ State { stPath = oldpath }, selectors)
+    mapfun (tests, events, ss@State { stPath = oldpath }, selectors)
            (mfilter, selector, valid) =
       let
         ssWithPath = ss { stPath = Label "Outer" : oldpath }
@@ -385,7 +385,7 @@ genFilter sname =
                           suiteConcurrently = True, suiteOptions = [] }
           in
             (suite, [], HashMap.empty, zeroCounts)
-        buildSuite (tests, events, state @ State { stCounts = counts },
+        buildSuite (tests, events, state@State { stCounts = counts },
                     selectors) =
           let
             -- Build the test suite out of the name and test list, add
@@ -443,7 +443,7 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                                        cTried = tried1 })
               (suite2, events2, selectormap2, counts2) =
   let
-    bumpCounts (EndEvent c @ Counts { cAsserts = asserts2,
+    bumpCounts (EndEvent c@Counts { cAsserts = asserts2,
                                       cCases = cases2,
                                       cErrors = errors2,
                                       cFailures = failures2,
@@ -455,8 +455,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                    cFailures = failures1 + failures2,
                    cSkipped = skipped1 + skipped2,
                    cTried = tried1 + tried2 }
-    bumpCounts (StartSuiteEvent s @ State { stCounts =
-                                              c @ Counts { cAsserts = asserts2,
+    bumpCounts (StartSuiteEvent s@State { stCounts =
+                                              c@Counts { cAsserts = asserts2,
                                                            cCases = cases2,
                                                            cErrors = errors2,
                                                            cFailures = failures2,
@@ -468,8 +468,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                          cFailures = failures1 + failures2,
                                          cSkipped = skipped1 + skipped2,
                                          cTried = tried1 + tried2 } }
-    bumpCounts (EndSuiteEvent s @ State { stCounts =
-                                            c @ Counts { cAsserts = asserts2,
+    bumpCounts (EndSuiteEvent s@State { stCounts =
+                                            c@Counts { cAsserts = asserts2,
                                                          cCases = cases2,
                                                          cErrors = errors2,
                                                          cFailures = failures2,
@@ -481,8 +481,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                        cFailures = failures1 + failures2,
                                        cSkipped = skipped1 + skipped2,
                                        cTried = tried1 + tried2 } }
-    bumpCounts (StartCaseEvent s @ State { stCounts =
-                                             c @ Counts { cAsserts = asserts2,
+    bumpCounts (StartCaseEvent s@State { stCounts =
+                                             c@Counts { cAsserts = asserts2,
                                                           cCases = cases2,
                                                           cErrors = errors2,
                                                           cFailures = failures2,
@@ -494,8 +494,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                         cFailures = failures1 + failures2,
                                         cSkipped = skipped1 + skipped2,
                                         cTried = tried1 + tried2 } }
-    bumpCounts (EndCaseEvent s @ State { stCounts =
-                                           c @ Counts { cAsserts = asserts2,
+    bumpCounts (EndCaseEvent s@State { stCounts =
+                                           c@Counts { cAsserts = asserts2,
                                                         cCases = cases2,
                                                         cErrors = errors2,
                                                         cFailures = failures2,
@@ -507,8 +507,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                       cFailures = failures1 + failures2,
                                       cSkipped = skipped1 + skipped2,
                                       cTried = tried1 + tried2 } }
-    bumpCounts (SkipEvent s @ State { stCounts =
-                                        c @ Counts { cAsserts = asserts2,
+    bumpCounts (SkipEvent s@State { stCounts =
+                                        c@Counts { cAsserts = asserts2,
                                                      cCases = cases2,
                                                      cErrors = errors2,
                                                      cFailures = failures2,
@@ -520,8 +520,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                    cFailures = failures1 + failures2,
                                    cSkipped = skipped1 + skipped2,
                                    cTried = tried1 + tried2 } }
-    bumpCounts (ProgressEvent msg s @ State { stCounts =
-                                                c @ Counts { cAsserts = asserts2,
+    bumpCounts (ProgressEvent msg s@State { stCounts =
+                                                c@Counts { cAsserts = asserts2,
                                                              cCases = cases2,
                                                              cErrors = errors2,
                                                              cFailures = failures2,
@@ -533,8 +533,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                            cFailures = failures1 + failures2,
                                            cSkipped = skipped1 + skipped2,
                                            cTried = tried1 + tried2 } }
-    bumpCounts (FailureEvent msg s @ State { stCounts =
-                                               c @ Counts { cAsserts = asserts2,
+    bumpCounts (FailureEvent msg s@State { stCounts =
+                                               c@Counts { cAsserts = asserts2,
                                                             cCases = cases2,
                                                             cErrors = errors2,
                                                             cFailures = failures2,
@@ -546,8 +546,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                           cFailures = failures1 + failures2,
                                           cSkipped = skipped1 + skipped2,
                                           cTried = tried1 + tried2 } }
-    bumpCounts (ErrorEvent msg s @ State { stCounts =
-                                             c @ Counts { cAsserts = asserts2,
+    bumpCounts (ErrorEvent msg s@State { stCounts =
+                                             c@Counts { cAsserts = asserts2,
                                                           cCases = cases2,
                                                           cErrors = errors2,
                                                           cFailures = failures2,
@@ -559,8 +559,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                         cFailures = failures1 + failures2,
                                         cSkipped = skipped1 + skipped2,
                                         cTried = tried1 + tried2 } }
-    bumpCounts (SystemErrEvent msg s @ State { stCounts =
-                                                 c @ Counts { cAsserts = asserts2,
+    bumpCounts (SystemErrEvent msg s@State { stCounts =
+                                                 c@Counts { cAsserts = asserts2,
                                                               cCases = cases2,
                                                               cErrors = errors2,
                                                               cFailures = failures2,
@@ -572,8 +572,8 @@ combineSuites (suite1, events1, selectormap1, Counts { cAsserts = asserts1,
                                             cFailures = failures1 + failures2,
                                             cSkipped = skipped1 + skipped2,
                                             cTried = tried1 + tried2 } }
-    bumpCounts (SystemOutEvent msg s @ State { stCounts =
-                                                 c @ Counts { cAsserts = asserts2,
+    bumpCounts (SystemOutEvent msg s@State { stCounts =
+                                                 c@Counts { cAsserts = asserts2,
                                                               cCases = cases2,
                                                               cErrors = errors2,
                                                               cFailures = failures2,

--- a/test/Tests/Test/HUnitPlus/ReporterUtils.hs
+++ b/test/Tests/Test/HUnitPlus/ReporterUtils.hs
@@ -65,33 +65,33 @@ initState = State { stName = "", stPath = [], stCounts = zeroCounts,
                     stOptions = HashMap.empty, stOptionDescs = [] }
 
 setName :: Strict.Text -> ReporterOp us
-setName name (s @ State { stName = _ }, repstate) =
+setName name (s@State { stName = _ }, repstate) =
   return (s { stName = name }, repstate)
 
 setOpt :: Strict.Text -> Strict.Text -> ReporterOp us
-setOpt key value (s @ State { stOptions = opts }, repstate) =
+setOpt key value (s@State { stOptions = opts }, repstate) =
   return (s { stOptions = HashMap.insert key value opts }, repstate)
 
 pushPath :: Strict.Text -> ReporterOp us
-pushPath name (s @ State { stPath = path }, repstate) =
+pushPath name (s@State { stPath = path }, repstate) =
   return (s { stPath = Label name : path }, repstate)
 
 popPath :: ReporterOp us
-popPath (s @ State { stPath = _ : path }, repstate) =
+popPath (s@State { stPath = _ : path }, repstate) =
   return (s { stPath = path }, repstate)
 
 addOption :: Strict.Text -> Strict.Text -> ReporterOp us
-addOption key value (s @ State { stOptions = opts }, repstate) =
+addOption key value (s@State { stOptions = opts }, repstate) =
   return (s { stOptions = HashMap.insert key value opts }, repstate)
 
 countAsserts :: Word -> ReporterOp us
-countAsserts count (s @ State { stCounts = c @ Counts { cAsserts = n } },
+countAsserts count (s@State { stCounts = c@Counts { cAsserts = n } },
                     repstate) =
   return (s { stCounts = c { cAsserts = n + count,
                              cCaseAsserts = count } }, repstate)
 
 countTried :: Word -> ReporterOp us
-countTried count (s @ State { stCounts = c @ Counts { cCases = cases,
+countTried count (s@State { stCounts = c@Counts { cCases = cases,
                                                       cTried = tried } },
                   repstate) =
   return (s { stCounts = c { cCases = cases + count,
@@ -99,7 +99,7 @@ countTried count (s @ State { stCounts = c @ Counts { cCases = cases,
           repstate)
 
 countSkipped :: Word -> ReporterOp us
-countSkipped count (s @ State { stCounts = c @ Counts { cSkipped = skipped,
+countSkipped count (s@State { stCounts = c@Counts { cSkipped = skipped,
                                                         cCases = cases } },
                   repstate) =
   return (s { stCounts = c { cSkipped = skipped + count,
@@ -107,12 +107,12 @@ countSkipped count (s @ State { stCounts = c @ Counts { cSkipped = skipped,
           repstate)
 
 countErrors :: Word -> ReporterOp us
-countErrors count (s @ State { stCounts = c @ Counts { cErrors = errors } },
+countErrors count (s@State { stCounts = c@Counts { cErrors = errors } },
                    repstate) =
   return (s { stCounts = c { cErrors = errors + count } }, repstate)
 
 countFailed :: Word -> ReporterOp us
-countFailed count (s @ State { stCounts = c @ Counts { cFailures = failed } },
+countFailed count (s@State { stCounts = c@Counts { cFailures = failed } },
                    repstate) =
   return (s { stCounts = c { cFailures = failed + count } }, repstate)
 
@@ -177,7 +177,7 @@ reportEndSuite reporter time (state, repstate) =
     return (state, repstate')
 
 reportEnd :: Reporter us -> Double -> ReporterOp us
-reportEnd reporter time (state @ State { stCounts = counts }, repstate) =
+reportEnd reporter time (state@State { stCounts = counts }, repstate) =
   do
     repstate' <- (reporterEnd reporter) time counts repstate
     return (state, repstate')

--- a/test/Tests/Test/HUnitPlus/XML.hs
+++ b/test/Tests/Test/HUnitPlus/XML.hs
@@ -39,7 +39,7 @@ reportEnd = Utils.reportEnd xmlReporter
 reportEndSuite :: Double -> ReporterOp
 reportEndSuite time state =
   let
-    removeTimestamp ((e @ Element { eAttributes = attrs } : rest) : stack) =
+    removeTimestamp ((e@Element { eAttributes = attrs } : rest) : stack) =
       (e { eAttributes = filter ((/= "timestamp") . fst) attrs } : rest) : stack
     removeTimestamp out = out
   in do


### PR DESCRIPTION
Modern versions of GHC implement a syntax change, described at

    https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst

, which requires as-patterns (x@pat) to be 'tight infix' expressions, meaning no whitespace is used on either side of the @ operator.

This removes the whitespace from all as-patterns in the code base, allowing the code and tests to be compiled under modern versions of GHC.